### PR TITLE
references for mysql 5.6 at least.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,9 +43,9 @@ AutoSequelize.prototype.run = function(options, callback) {
           // map sqlite's PRAGMA results
           ref = Sequelize.Utils._.assign(ref, {
             source_table: table,
-            source_column: ref.from,
-            target_table: ref.table,
-            target_column: ref.to
+            source_column: ref.source_column,
+            target_table: ref.target_table,
+            target_column: ref.target_column
           });
 
           if (ref.source_column && ref.target_column) {


### PR DESCRIPTION
the ref variable in my mysql 5.6.26 gave a bunch of undefined in all but source_table. So reading a bit of documentation, I fixed that and now it saves the references in models for columns.
I don't know if it will work on postgresql or others, please test.